### PR TITLE
Do not store duplicated fields

### DIFF
--- a/cchloader/backends/timescaledb.py
+++ b/cchloader/backends/timescaledb.py
@@ -57,8 +57,6 @@ class TimescaleDBBackend(BaseBackend):
         batch = []
         for curve in curves:
             curve.update({
-                'create_at': datetime.datetime.now().strftime('%Y-%m-%d %H:%M:%S'),
-                'update_at': datetime.datetime.now().strftime('%Y-%m-%d %H:%M:%S'),
                 'create_date': datetime.datetime.now().strftime('%Y-%m-%d %H:%M:%S'),
                 'create_uid': 1,
                 'utc_timestamp': get_as_utc_timestamp(curve['datetime'], curve['name'], curve.get('season')).strftime('%Y-%m-%d %H:%M:%S')


### PR DESCRIPTION
## Description

Only store ORM `create_date` field to match the ORM behaviour.

## Changes

- Do not set curve `create_at` and `update_at`.

## Observations

https://trello.com/c/C7OjwDM5/160-p12-ep260-migrar-camps-createdat-i-updatedat-de-les-corbes



