### PR TITLE
Arreglar la publicació a pypi.org

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -32,7 +32,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install build
+        python setup.py sdist bdist_wheel
 
     - name: Build package
       run: python -m build


### PR DESCRIPTION
## Description
Arreglar la publicació a pypi.org

## Changes

- Deixem de fer servir python build perquè no trovaba el requirements.txt

